### PR TITLE
hotfix: Make sure things that should be filtered are filtered

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -768,8 +768,9 @@ exports.filter = (() => {
 		})
 
 		const filterValidator = filterAjv.compile(filterSchema)
-		const matchValidator = matchAjv.compile(
+		const permissiveValidator = matchAjv.compile(
 			allowAdditionalProperties(_.cloneDeep(schema)))
+		const matchValidator = matchAjv.compile(_.cloneDeep(schema))
 
 		// A flag to help inform the return type
 		const calledWithArray = _.isArray(object)
@@ -811,6 +812,7 @@ exports.filter = (() => {
 					disallowAdditionalProperties(mergedFragment, {
 						force: options.force
 					})
+
 				const filter = filterAjv.compile(fragmentFilterSchema)
 				return {
 					match,
@@ -824,7 +826,8 @@ exports.filter = (() => {
 		const result = items.reduce((carry, item) => {
 			// First check to see if the item validates against any fragement
 			// validators
-			if (fragmentValidators.length && matchValidator(item)) {
+			if (fragmentValidators.length && (matchValidator(item) ||
+				permissiveValidator(item))) {
 				for (const fragmentValidator of fragmentValidators) {
 					if (fragmentValidator.match(item)) {
 						if (fragmentValidator.filter(item)) {
@@ -848,7 +851,7 @@ exports.filter = (() => {
 		// If the function was called with an array, return an array, otherwise
 		// return the first array element, or null if its undefined
 		if (calledWithArray) {
-			return result
+			return result.filter(matchValidator)
 		}
 
 		return _.first(result) || null


### PR DESCRIPTION
This is a hack, and should be reverted once we get to the bottom of it.
It will impact performance, but right now there are things that should
be filtered and are not, so lets get this merged for security purposes.
Hopefully this library will be re-written soon.

Change-type: patch
See: https://github.com/balena-io/jellyfish/pull/878