### PR TITLE
Set addUsedSchema to false in all AJV instances

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -507,7 +507,11 @@ exports.scoreMatch = (schema, object) => {
 exports.match = (() => {
 	const ajv = new AJV({
 		allErrors: true,
-		unknownFormats: 'ignore'
+		unknownFormats: 'ignore',
+
+		// Don't keep references to all used
+		// schemas in order to not leak memory.
+		addUsedSchema: false
 	})
 
 	ajv
@@ -855,13 +859,21 @@ exports.filter = (() => {
 	const filterAjv = new AJV({
 		// https://github.com/epoberezkin/ajv#filtering-data
 		removeAdditional: true,
-		unknownFormats: 'ignore'
+		unknownFormats: 'ignore',
+
+		// Don't keep references to all used
+		// schemas in order to not leak memory.
+		addUsedSchema: false
 	})
 
 	// Create an instance of AJV that will be used to perform simple matchin
 	const matchAjv = new AJV({
 		allErrors: true,
-		unknownFormats: 'ignore'
+		unknownFormats: 'ignore',
+
+		// Don't keep references to all used
+		// schemas in order to not leak memory.
+		addUsedSchema: false
 	})
 
 	configureAjv(filterAjv)


### PR DESCRIPTION
So we don't leak `SchemaObject` in the AJV `_refs` object.

Change-type: patch