### PR TITLE
Fixed compatibility issues with pattern matching variable assignments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1272,13 +1272,11 @@ const combineWithBaseSchema = (baseSchema, fragment) => {
 			// the enum values need to be merged together with an AND operator
 			// to do this we recreate the subschema to use allOf
 			if (sourceValue && objectValue && sourceValue.enum && objectValue.enum) {
-				const {
-					enum: enumObject, ...restObject
-				} = objectValue
+				const enumObject = objectValue.enum
+				const restObject = omit(objectValue, [ 'enum' ])
 
-				const {
-					enum: enumSource, ...restSource
-				} = sourceValue
+				const enumSource = sourceValue.enum
+				const restSource = omit(sourceValue, [ 'enum' ])
 
 				const newObject =	merge(restSource, restObject)
 


### PR DESCRIPTION
I noticed when updating Contrato that when I run the browser test with `karma` I get the following error:

```
ERROR in ./node_modules/skhema/lib/index.js
Module parse failed: Unexpected token (1276:23)
You may need an appropriate loader to handle this file type.
| 			if (sourceValue && objectValue && sourceValue.enum && objectValue.enum) {
| 				const {
| 					enum: enumObject, ...restObject
| 				} = objectValue
```

It seems like there is some sort of compatibility issues using this pattern matching assignments for accessing objects. I updated the code to fix this and the issues when running `karma` on Contrato have gone away now.

Change-type: patch
Signed-off-by: Micah Halter <micah@balena.io>