### PR TITLE
Enable data option for match

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -521,6 +521,7 @@ exports.match = (() => {
 		allErrors: true,
 		unknownFormats: 'ignore',
 		cache,
+		$data: true,
 
 		// Don't keep references to all used
 		// schemas in order to not leak memory.


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Enable [`$data` option](https://ajv.js.org/guide/combining-schemas.html#data-reference) for `match()` so we can do more dynamic things like this when validating schemas:
```json
{
    "type":"object",
    "properties":{
        "start":{
            "type":"string",
            "format":"date-time"
        },
        "end":{
            "type":"string",
            "format":"date-time",
            "formatMinimum":{
                "$data":"1/start"
            }
        }
    }
}
```