### PR TITLE
Upgrade to latest version of lru-cache module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4186,11 +4186,11 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "requires": {
-        "yallist": "^3.0.2"
+        "yallist": "^4.0.0"
       }
     },
     "make-dir": {
@@ -9168,9 +9168,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "json-schema-faker": "^0.5.0-rc16",
     "json-schema-merge-allof": "^0.6.0",
     "lodash": "^4.17.19",
-    "lru-cache": "^5.1.1",
+    "lru-cache": "^6.0.0",
     "typed-error": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "type": "git",
     "url": "git@github.com:balena-io-modules/skhema.git"
   },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "test": "npm run lint && nyc --reporter=lcov ava -v",
     "mutate": "stryker run",


### PR DESCRIPTION
This update was a major change to the lru-cache dependency. AFAICT the
interface remains the same, and the breaking change is that only node
versions >= 10 are supported now.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>