### PR TITLE
Properly combine anyOf on merge

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -717,7 +717,7 @@ exports.merge = (schemas, options = {}) => {
 		if (mergedSchemas.anyOf && mergedSchemas.anyOf.length === 1) {
 			const [ anyOf ] = mergedSchemas.anyOf
 
-			return merge(omit(mergedSchemas, 'anyOf'), anyOf)
+			return combineAnyOf(omit(mergedSchemas, 'anyOf'), anyOf)
 		}
 
 		return mergedSchemas
@@ -1370,7 +1370,7 @@ const combineWithBaseSchema = (baseSchema, fragment) => {
  * }
  */
 const combineSchemas = (left, right, customizer) => {
-	// Merge fragment schema with scehma values defined at the top level
+	// Merge fragment schema with schema values defined at the top level
 	// - Defaults schema `type` to 'object'
 	// - Removes any $id attribute, as we may be compiling the same $id
 	//   multiple times

--- a/test/merge.json
+++ b/test/merge.json
@@ -777,5 +777,54 @@
 			"type": "object",
       "additionalProperties": true
 		}
+	},
+	{
+		"schemas": [
+			{
+				"type": "object",
+				"properties": {
+					"type": {
+						"type": "string"
+					},
+					"data": {
+						"type": "object"
+					}
+				},
+				"required": [ "type", "data" ]
+			},
+			{
+				"type": "object",
+				"anyOf": [
+					{
+						"type": "object",
+						"properties": {
+							"name": {
+								"type": "string"
+							},
+							"data": {
+								"type": "object"
+							}
+						},
+						"required": [ "name", "data" ]
+					}
+				]
+			}
+		],
+		"expected": {
+			"type": "object",
+			"additionalProperties": true,
+			"properties": {
+				"type": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"data": {
+					"type": "object"
+				}
+			},
+			"required": [ "data", "name", "type" ]
+		}
 	}
 ]


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Fix for https://github.com/balena-io-modules/skhema/issues/88

Using lodash's `merge()` as-is results in child array values being overwritten, causing the problem described in the linked issue. Quick example:
```javascript
const _ = require('lodash');

const schema1 = {
        required: ['data']
};

const schema2 = {
        required: ['name']
};

console.log(JSON.stringify(_.merge(schema1, schema2), null, 4));
```

Results in:
```
{
    "required": [
        "name"
    ]
}
```